### PR TITLE
Add Wikipedia to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Example-iOS-Apps is an amazing list for people who are begginers and learning io
 * [Recipes App](https://github.com/onmyway133/Recipes) - An app that showcases many recipes together with their detail information
 * [PixPic](https://github.com/Yalantis/PixPic) - Photo editing app
 * [Brave iOS Browser](https://github.com/brave/browser-ios) - Brave is based on Firefox iOS
-* [Todoey](https://github.com/tiannahenrylewis/Todoey) - To Do App 
+* [Todoey](https://github.com/tiannahenrylewis/Todoey) - To Do App
+* [Wikipedia](https://github.com/wikimedia/wikipedia-ios) - Official Wikipedia iOS App
+
 ## Author
 
 <table>


### PR DESCRIPTION
## Project URL
https://github.com/wikimedia/wikipedia-ios

## Description
Official Wikipedia iOS App

## Why it should be included to `example-ios-apps` (optional)
I added the official app for Wikipedia to the list. It is not purely Swift, but the parts that are, are well written and good "real-world" examples of Swift code, e.g. using `@IBDesignable` and `@IBInspectable` for custom views in storyboards.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English