### PR TITLE
typo error

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Example-iOS-Apps is an amazing list for people who are beginners and learning iO
 * [Catty](https://github.com/Catrobat/Catty) - iOS implementation of the Catrobat language.
 * [Amahi](https://github.com/amahi/ios) - iOS application written in Swift, from scratch.
 * [Phimp.me](https://github.com/jogendra/phimpme-iOS) - Photo Image Editor and Sharing App.
-* [Catty](https://github.com/Catrobat/Catty) - iOS implementation of the Catrobat language.
 * [Matrix iOS SDK](https://github.com/matrix-org/matrix-ios-sdk) - The Matrix SDK for iOS.
 * [Kiwix Apple](https://github.com/kiwix/apple) - iOS and macOS implementation of Kiwix.
 


### PR DESCRIPTION
Catty inside the GSoC section come twice

## Project Url
https://github.com/jogendra/example-ios-apps

## Description
<!--- Describe your changes in detail -->
 
## Why it should be included to `example-ios-apps` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Addition in chronological order (bottom of category)
- [ ] Supports iOS 9 / tvOS 10 or later
- [ ] Supports Swift 3 or later
- [ ] Has a commit from less than 2 years ago
- [ ] Has a **clear** README in English
