### PR TITLE
Add AC Helper and Puffery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Example-iOS-Apps is an amazing list for people who are beginners and learning iO
 * [Harvest-SwiftUI-Gallery](https://github.com/inamiy/Harvest-SwiftUI-Gallery) - Gallery App for Harvest (Elm Architecture + Optics) + SwiftUI + Combine.
 * [SwiftWebUI](https://github.com/SwiftWebUI/SwiftWebUI) - A demo implementation of SwiftUI for the Web
 * [8 Ball](https://github.com/fulldecent/8-ball) - A fully working iOS + watchOS game to make life choices
+* [AC Helper](https://github.com/Dimillian/ACHNBrowserUI) - Animal Crossing New Horizon companion app in SwiftUI
+* [Puffery](https://github.com/vknabel/puffery) - An iOS App written in SwiftUI to send push notifications fueled by Siri Shortcuts
 
 ## iOS Apps written with SceneKit
 * [Pizza Man](https://github.com/fulldecent/pizzaman) - A simple game where you eat flying pepperoni


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
<!--- The project URL -->
1. https://github.com/Dimillian/ACHNBrowserUI (<- I contributed to it)
2. https://github.com/vknabel/puffery (<- my app)

## Description
<!--- Describe your changes in detail -->
Adds AC Helper and Puffery apps
 
## Why it should be included to `example-ios-apps` (optional)

Both apps are already on the App Store.
1. AC Helper has quite a lot features and localizations. Quite interesting and view-heavy (many screens).
2. Puffery is a mono-repo for iOS app and Vapor-Server which share the same structs. Much smaller app with just a bunch of views.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
