### PR TITLE
Add CalendarApp example

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Example-iOS-Apps is an amazing list for people who are beginners and learning iO
 * [ProgressGif](https://github.com/aheze/ProgressGif) - Add progress bars to gifs. Realm for project storage + Real time video editor + Renderer.
 * [Telegram](https://github.com/TelegramMessenger/Telegram-iOS) - Official Telegram Messenger for iOS
 * [CaptchaDemo](https://github.com/tanvijn/CaptchaDemo_ios) - A LightWeight Swift project to showcase implementation of Google ReCaptcha in iOS Application.
+* [CalendarApp](https://github.com/richardtop/CalendarApp) - A sample app similar to iOS Calendar, built with CalendarKit in less than 100 lines of code.
 
 
 ## Author


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://github.com/richardtop/CalendarApp

## Description
CalendarApp is a template repository serving as a starting point for experiments with CalendarKit. It's a sample calendar app for iOS built with CalendarKit and EventKit. It displays events stored in the EKEventStore similarly to the default calendar app.
 
## Why it should be included to `example-ios-apps` (optional)

Great starting point in building calendar experiences, very simple.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in chronological order (bottom of category)
- [x] Supports iOS 9 / tvOS 10 or later
- [x] Supports Swift 3 or later
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English
